### PR TITLE
Mods for v2.0.1

### DIFF
--- a/examples/get_computer_dn.rb
+++ b/examples/get_computer_dn.rb
@@ -26,4 +26,4 @@ computer_cn = '__ComputerCN__'
 c = AdManagement::Client.new(conf).connect!
 
 ## Display a computer accounts DistinguishedName
-puts c.get(computer_cn + '$')
+puts c.get(computer_cn)

--- a/lib/ad_management/objects/computer.rb
+++ b/lib/ad_management/objects/computer.rb
@@ -5,10 +5,10 @@ module AdManagement
     module Computer
       ##
       # Gets the dn of a computer object
-      def get(sam_account_name)
-        raise AdManagement::ArgumentError, 'Required parameter sam_account_name not provided!' if sam_account_name.nil?
-        @logger.info("Getting DN of #{sam_account_name}")
-        dn = search(sam_account_name + '$').first&.dn || ''
+      def get(cn)
+        raise AdManagement::ArgumentError, 'Required parameter cn not provided!' if cn.nil?
+        @logger.info("Getting DN of #{cn}")
+        dn = search(cn + '$').first&.dn || ''
         dn
       end
 

--- a/lib/ad_management/objects/computer.rb
+++ b/lib/ad_management/objects/computer.rb
@@ -39,7 +39,8 @@ module AdManagement
             objectClass: %w[computer organizationalPerson person top user],
             cn: cn,
             sAMAccountName: cn + '$',
-            managedBy: managed_by_dn
+            managedBy: managed_by_dn,
+            userAccountControl: '4096'
           }
         )
         return "CN=#{cn},#{ou}" if result

--- a/lib/ad_management/version.rb
+++ b/lib/ad_management/version.rb
@@ -1,3 +1,3 @@
 module AdManagement
-  VERSION = '2.0.0'.freeze
+  VERSION = '3.0.0'.freeze
 end


### PR DESCRIPTION
I made the following small changes:

- In `computer.rb`, the parameter `sam_account_name` of `#get` method was changed to `cn` since the method appends the `$` sign to the parameter value to generate the SAMAccountName.

- In the example `get_computer_dn.rb`, the `$` sign in the method invocation was  removed to reflect the above change.

- In `computer.rb`, a new computer object attribute `userAccountControl` with a default value of `'4096'` was added to `#create` method.

Should this be a Major version change, given the first modification `computer.rb` and the corresponding change in invoking `#get` ?